### PR TITLE
Provide option to re-tag the source image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 pipeline-bundle-list
 task-bundle-list
+bundle_values.env

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -137,7 +137,7 @@ spec:
                   [[ -f "$f" ]] && list+=("$f")
                 done
 
-                .tekton/scripts/build-acceptable-bundles.sh "${list[*]}"
+                .tekton/scripts/build-acceptable-bundles.sh "${list[@]}"
 
                 echo -n "${DATA_BUNDLE_TAG}" > acceptable_bundle_tag
               args:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -42,20 +42,6 @@ spec:
           - name: output
             workspace: workspace
 
-      - name: clone-repository-to-redhat-appstudio-workspace
-        params:
-          - name: url
-            value: $(params.git-url)
-          - name: revision
-            value: "$(params.revision)"
-          - name: depth
-            value: "0"
-        taskRef:
-          name: git-clone
-        workspaces:
-          - name: output
-            workspace: workspace-redhat-appstudio
-
       - name: ec-task-checks
         runAfter:
           - clone-repository
@@ -78,55 +64,12 @@ spec:
           - name: source
             workspace: workspace
 
-      - name: build-bundles-redhat-appstudio
+      - name: build-bundles
         params:
           - name: revision
             value: "$(params.revision)"
         runAfter:
-          - build-container
-          - clone-repository-to-redhat-appstudio-workspace
-        workspaces:
-          - name: source
-            workspace: workspace-redhat-appstudio
-        taskSpec:
-          params:
-            - name: revision
-              type: string
-          steps:
-            - name: build-bundles
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
-              workingDir: $(workspaces.source.path)/source
-              command: ["./hack/build-and-push.sh"]
-              env:
-                - name: QUAY_NAMESPACE
-                  value: redhat-appstudio-tekton-catalog
-                - name: BUILD_TAG
-                  value: "$(params.revision)"
-                - name: SKIP_BUILD
-                  value: "1"
-                - name: SKIP_INSTALL
-                  value: "1"
-                - name: OUTPUT_TASK_BUNDLE_LIST
-                  value: $(workspaces.source.path)/task-bundle-list
-                - name: OUTPUT_PIPELINE_BUNDLE_LIST
-                  value: $(workspaces.source.path)/pipeline-bundle-list
-              volumeMounts:
-                - mountPath: /root/.docker/config.json
-                  subPath: .dockerconfigjson
-                  name: quay-secret
-          volumes:
-          - name: quay-secret
-            secret:
-              secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
-          workspaces:
-            - name: source
-
-      - name: build-bundles-konflux-ci
-        params:
-          - name: revision
-            value: "$(params.revision)"
-        runAfter:
-          - build-container
+          - ec-task-checks
         workspaces:
           - name: source
             workspace: workspace
@@ -135,7 +78,7 @@ spec:
             - name: revision
               type: string
           steps:
-            - name: build-bundles
+            - name: build-bundles-konflux-ci
               image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
@@ -149,16 +92,86 @@ spec:
                 - name: SKIP_INSTALL
                   value: "1"
                 - name: OUTPUT_TASK_BUNDLE_LIST
-                  value: $(workspaces.source.path)/task-bundle-list
+                  value: $(workspaces.source.path)/task-bundle-list-konflux-ci
                 - name: OUTPUT_PIPELINE_BUNDLE_LIST
-                  value: $(workspaces.source.path)/pipeline-bundle-list
+                  value: $(workspaces.source.path)/pipeline-bundle-list-konflux-ci
+            - name: build-bundles-redhat-appstudio
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              workingDir: $(workspaces.source.path)/source
+              command: ["./hack/build-and-push.sh"]
+              env:
+                - name: QUAY_NAMESPACE
+                  value: redhat-appstudio-tekton-catalog
+                - name: BUILD_TAG
+                  value: "$(params.revision)"
+                - name: SKIP_BUILD
+                  value: "1"
+                - name: SKIP_INSTALL
+                  value: "1"
+                - name: OUTPUT_TASK_BUNDLE_LIST
+                  value: $(workspaces.source.path)/task-bundle-list-appstudio
+                - name: OUTPUT_PIPELINE_BUNDLE_LIST
+                  value: $(workspaces.source.path)/pipeline-bundle-list-appstudio
+              volumeMounts:
+                - mountPath: /root/.docker/config.json
+                  subPath: .dockerconfigjson
+                  name: quay-secret
+            - name: update-acceptable-bundles
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              workingDir: $(workspaces.source.path)/source
+              env:
+              - name: REVISION
+                value: "$(params.revision)"
+              - name: GIT_URL
+                value: "$(params.git-url)"
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+
+                DATA_BUNDLE_REPO=quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles
+                DATA_BUNDLE_TAG=$(date '+%s')
+                export DATA_BUNDLE_REPO DATA_BUNDLE_TAG
+
+                .tekton/scripts/build-acceptable-bundles.sh "$@"
+
+                echo -n "${DATA_BUNDLE_TAG}" > acceptable_bundle_tag
+              args:
+                - $(workspaces.source.path)/task-bundle-list-konflux-ci
+                - $(workspaces.source.path)/pipeline-bundle-list-konflux-ci
+                - $(workspaces.source.path)/task-bundle-list-appstudio
+                - $(workspaces.source.path)/pipeline-bundle-list-appstudio
+            - name: copy-acceptable-bundle-to-appstudio
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              workingDir: $(workspaces.source.path)/source
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+
+                DATA_BUNDLE_REPO=quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles
+                DATA_BUNDLE_TAG=$(<acceptable_bundle_tag)
+                DATA_BUNDLE_RH_APPSTUDIO=quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles
+
+                skopeo copy \
+                  "docker://$DATA_BUNDLE_REPO:$DATA_BUNDLE_TAG" \
+                  "docker://$DATA_BUNDLE_RH_APPSTUDIO:$DATA_BUNDLE_TAG"
+
+                skopeo copy \
+                  "docker://$DATA_BUNDLE_REPO:$DATA_BUNDLE_TAG" \
+                  "docker://$DATA_BUNDLE_RH_APPSTUDIO:latest"
+              volumeMounts:
+                - mountPath: /root/.docker/config.json
+                  subPath: .dockerconfigjson
+                  name: quay-secret
+          volumes:
+          - name: quay-secret
+            secret:
+              secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
           workspaces:
             - name: source
 
       - name: update-infra-repo
         runAfter:
-          - build-bundles-redhat-appstudio
-          - build-bundles-konflux-ci
+          - build-bundles
         params:
           - name: ORIGIN_REPO
             value: $(params.git-url)
@@ -170,93 +183,9 @@ spec:
         taskRef:
           name: update-infra-deployments
 
-      # Note: pushes to redhat-appstudio-tekton-catalog, but contains the bundles
-      # from both redhat-appstudio-tekton-catalog and konflux-ci/tekton-catalog
-      - name: build-acceptable-bundles-redhat-appstudio
-        runAfter:
-          - build-bundles-redhat-appstudio
-          - build-bundles-konflux-ci
-        workspaces:
-          - name: artifacts
-            workspace: workspace
-          - name: artifacts-redhat-appstudio
-            workspace: workspace-redhat-appstudio
-        taskSpec:
-          workspaces:
-            - name: artifacts
-              description: Workspace containing arbitrary artifacts used during the task run.
-            - name: artifacts-redhat-appstudio
-              description: Same as 'artifacts', but for tasks that push to the old redhat-appstudio location.
-          volumes:
-          - name: quay-secret
-            secret:
-              secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
-          results:
-          - name: DATA_BUNDLE_REPO
-          - name: DATA_BUNDLE_TAG
-          steps:
-            - name: build-bundles
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
-              workingDir: $(workspaces.artifacts.path)/source
-              env:
-              - name: REVISION
-                value: "$(params.revision)"
-              - name: GIT_URL
-                value: "$(params.git-url)"
-              script: |
-                #!/bin/bash
-                set -euo pipefail
-
-                DATA_BUNDLE_REPO=quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles
-                DATA_BUNDLE_TAG=$(date '+%s')
-                export DATA_BUNDLE_REPO DATA_BUNDLE_TAG
-
-                .tekton/scripts/build-acceptable-bundles.sh "$@"
-
-                echo -n "$DATA_BUNDLE_REPO" > "$(results.DATA_BUNDLE_REPO.path)"
-                echo -n "$DATA_BUNDLE_TAG" > "$(results.DATA_BUNDLE_TAG.path)"
-              args:
-                - $(workspaces.artifacts.path)/task-bundle-list
-                - $(workspaces.artifacts.path)/pipeline-bundle-list
-                - $(workspaces.artifacts-redhat-appstudio.path)/task-bundle-list
-                - $(workspaces.artifacts-redhat-appstudio.path)/pipeline-bundle-list
-              volumeMounts:
-                - mountPath: /root/.docker/config.json
-                  subPath: .dockerconfigjson
-                  name: quay-secret
-
-      # Note: copies the redhat-appstudio-tekton-catalog data-acceptable-bundles image
-      - name: build-acceptable-bundles-konflux-ci
-        runAfter:
-          - build-acceptable-bundles-redhat-appstudio
-        taskSpec:
-          steps:
-            - name: copy-bundles
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
-              env:
-              - name: DATA_BUNDLE_RH_APPSTUDIO
-                value: $(tasks.build-acceptable-bundles-redhat-appstudio.results.DATA_BUNDLE_REPO)
-              - name: DATA_BUNDLE_TAG
-                value: $(tasks.build-acceptable-bundles-redhat-appstudio.results.DATA_BUNDLE_TAG)
-              script: |
-                #!/bin/bash
-                set -euo pipefail
-                set -x
-
-                DATA_BUNDLE_KONFLUX_CI=quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles
-
-                skopeo copy \
-                  "docker://$DATA_BUNDLE_RH_APPSTUDIO:$DATA_BUNDLE_TAG" \
-                  "docker://$DATA_BUNDLE_KONFLUX_CI:$DATA_BUNDLE_TAG"
-
-                skopeo copy \
-                  "docker://$DATA_BUNDLE_KONFLUX_CI:$DATA_BUNDLE_TAG" \
-                  "docker://$DATA_BUNDLE_KONFLUX_CI:latest"
     workspaces:
       - name: workspace
         description: Workspace containing arbitrary artifacts used during the pipeline run.
-      - name: workspace-redhat-appstudio
-        description: Same as 'workspace', but for tasks that push to the old redhat-appstudio location.
     finally:
       - name: slack-webhook-notification
         taskRef:
@@ -275,14 +204,6 @@ spec:
           value: $(params.slack-webhook-notification-team)
   workspaces:
     - name: workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-redhat-appstudio
       volumeClaimTemplate:
         spec:
           accessModes:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -132,7 +132,12 @@ spec:
                 DATA_BUNDLE_TAG=$(date '+%s')
                 export DATA_BUNDLE_REPO DATA_BUNDLE_TAG
 
-                .tekton/scripts/build-acceptable-bundles.sh "$@"
+                list=()
+                for f in "$@"; do
+                  [[ -f "$f" ]] && list+=("$f")
+                done
+
+                .tekton/scripts/build-acceptable-bundles.sh "${list[*]}"
 
                 echo -n "${DATA_BUNDLE_TAG}" > acceptable_bundle_tag
               args:

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -26,7 +26,7 @@ spec:
       type: string
   steps:
     - name: e2e-test
-      image: quay.io/konflux-ci/e2e-tests:a1fd47cbb639276f08f9c51769a15a106a9e68ff
+      image: quay.io/redhat-user-workloads/rhtap-qe-shared-tenant/konflux-e2e/konflux-e2e-tests:7dab163f24f482021262680e7a602d6af84ca84b
       # a la infra-deployment updates, when PRs merge in e2e-tests, PRs will be opened
       # against build-definitions to update this tag
       args: [

--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -23,7 +23,7 @@ spec:
       $(all_tasks_dir all_tasks-ec)
   - name: validate-all-tasks
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:dc7d404596385e7d3c624ec0492524a1d57efe2b0c10cf0ec2158d49c0290a83
+    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:868c24978b21099988c09a7e35136db5219755e13a62c65247642ce13be6ec6b
     script: |
       set -euo pipefail
 
@@ -37,7 +37,7 @@ spec:
       ec validate input --policy "${policy}" --output yaml --strict=true ${args[*]}
   - name: validate-build-tasks
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:dc7d404596385e7d3c624ec0492524a1d57efe2b0c10cf0ec2158d49c0290a83
+    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:868c24978b21099988c09a7e35136db5219755e13a62c65247642ce13be6ec6b
     script: |
       set -euo pipefail
 

--- a/hack/generate-ta-tasks.sh
+++ b/hack/generate-ta-tasks.sh
@@ -34,6 +34,11 @@ emit() {
   changes=$((changes + 1))
 }
 
+msg="File is out of date and has been updated"
+if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
+  # shellcheck disable=SC2016
+  msg='File is out of date, run `hack/generate-ta-tasks.sh` and include the updated file with your changes'
+fi
 
 cd "${TASK_DIR}"
 for recipe_path in **/recipe.yaml; do
@@ -42,10 +47,10 @@ for recipe_path in **/recipe.yaml; do
     readme_path="${recipe_path%/recipe.yaml}/README.md"
     "${HACK_DIR}/generate-readme.sh" "${task_path}" > "${readme_path}"
     if ! git diff --quiet HEAD "${task_path}"; then
-        emit "task/${task_path}" "file is out of date and has been updated"
+        emit "task/${task_path}" "${msg}"
     fi
     if ! git diff --quiet HEAD "${readme_path}"; then
-        emit "task/${readme_path}" "file is out of date and has been updated"
+        emit "task/${readme_path}" "${msg}"
     fi
 done
 

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -73,7 +73,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:186ed09cdebd169a501ac8a379e7bc1a4f4d50ab5a5ec410a09058991c7f3699
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:41a5947107beba8cab3c3af1e4d9b9556c93b955d1f5c7224fc8ae68b050f1a2
           - name: name
             value: verify-enterprise-contract
           - name: kind

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -103,6 +103,8 @@ spec:
           workspace: workspace
         - name: git-basic-auth
           workspace: git-auth
+        - name: netrc
+          workspace: netrc
     - name: build-container
       when:
       - input: $(tasks.init.results.build)
@@ -275,4 +277,6 @@ spec:
   workspaces:
     - name: workspace
     - name: git-auth
+      optional: true
+    - name: netrc
       optional: true

--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -11,6 +11,7 @@ sources:
         - git-basic-auth
         - basic-auth
         - ssh-directory
+        - netrc
     config:
       include:
         - kind

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
         "quay.io/konflux-ci/pull-request-builds",
         "quay.io/redhat-appstudio/github-app-token",
         "quay.io/konflux-ci/appstudio-utils",
+        "quay.io/konflux-ci/source-container-build",
         "quay.io/redhat-appstudio/e2e-tests",
         "quay.io/redhat-appstudio/buildah",
         "quay.io/redhat-appstudio/syft",

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
         "quay.io/redhat-appstudio/clamav-db"
       ],
       "groupName": "integration",
-      "reviewers": ["dirgim", "hongweiliu17", "jsztuka", "Josh-Everett", "MartinBasti", "dheerajodha", "kasemAlem"]
+      "reviewers": ["dirgim", "hongweiliu17", "jsztuka", "Josh-Everett", " 14rcole", "chipspeak", "dheerajodha", "kasemAlem"]
     },
     {
       "matchPackageNames": [

--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/README.md
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/README.md
@@ -1,0 +1,12 @@
+# eaas-copy-secrets-to-ephemeral-cluster stepaction
+
+This StepAction copies Secrets from the current namespace into a configurable namespace on an ephemeral cluster. The name and content of each Secret is unaltered in the process.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|credentials|A volume containing credentials to the remote cluster||true|
+|kubeconfig|Relative path to the kubeconfig in the mounted cluster credentials volume||true|
+|namespace|The destination namespace for the secrets. The namespace must already exist.||true|
+|labelSelector|A label selector identifying the secrets to be copied||true|
+

--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: eaas-copy-secrets-to-ephemeral-cluster
+spec:
+  description: >-
+    This StepAction copies Secrets from the current namespace into a configurable namespace on an
+    ephemeral cluster. The name and content of each Secret is unaltered in the process.
+  image: quay.io/redhat-appstudio/appstudio-utils@sha256:586149e3f18d966f681d956ab074b4e1d8433663d615ed86e19a3804ba952dfe
+  params:
+    - name: credentials
+      type: string
+      description: A volume containing credentials to the remote cluster
+    - name: kubeconfig
+      type: string
+      description: Relative path to the kubeconfig in the mounted cluster credentials volume
+    - name: namespace
+      type: string
+      description: The destination namespace for the secrets. The namespace must already exist.
+    - name: labelSelector
+      type: string
+      description: A label selector identifying the secrets to be copied
+  env:
+    - name: DEST_KUBECONFIG
+      value: "/credentials/$(params.kubeconfig)"
+    - name: NAMESPACE
+      value: "$(params.namespace)"
+    - name: LABEL_SELECTOR
+      value: "$(params.labelSelector)"
+  volumeMounts:
+    - name: "$(params.credentials)"
+      mountPath: /credentials
+  script: |
+    #!/bin/bash
+    set -eo pipefail
+
+    oc get secrets -l "$LABEL_SELECTOR" -o json \
+      | jq ".items[].metadata.namespace=\"$NAMESPACE\"" \
+      | jq 'del(.items[] | .metadata.creationTimestamp,
+                .metadata.uid, .metadata.resourceVersion,
+                .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")' \
+      | oc apply --kubeconfig=$DEST_KUBECONFIG -f -

--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
@@ -35,7 +35,7 @@ spec:
     set -eo pipefail
 
     oc get secrets -l "$LABEL_SELECTOR" -o json \
-      | jq ".items[].metadata.namespace=\"$NAMESPACE\"" \
+      | jq --arg ns "$NAMESPACE" '.items[].metadata.namespace=$ns' \
       | jq 'del(.items[] | .metadata.creationTimestamp,
                 .metadata.uid, .metadata.resourceVersion,
                 .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")' \

--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/OWNERS
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- amisstea
+- oamsalem
+- avi-biton
+- yftacherzog
+- hmariset

--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/OWNERS
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - amisstea
-- oamsalem
+- omeramsc
 - avi-biton
 - yftacherzog
 - hmariset

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
@@ -1,0 +1,17 @@
+# eaas-create-ephemeral-cluster-hypershift-aws stepaction
+
+This StepAction provisions an ephemeral cluster using Hypershift with 3 worker nodes in AWS. It does so by creating a ClusterTemplateInstance in a space on an EaaS cluster.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|eaasSpaceSecretRef|Name of a secret containing credentials for accessing an EaaS space.||true|
+|version|The version of OpenShift to install. Container images will be pulled from: `quay.io/openshift-release-dev/ocp-release:${version}-multi`.||true|
+|instanceType|AWS EC2 instance type for worker nodes. Supported values: `m5.large`, `m5.xlarge`, `m5.2xlarge`, `m6g.large`, `m6g.xlarge`, `m6g.2xlarge`|m6g.large|false|
+|insecureSkipTLSVerify|Skip TLS verification when accessing the EaaS hub cluster. This should not be set to "true" in a production environment.|false|false|
+
+## Results
+|name|description|
+|---|---|
+|clusterName|The name of the generated ClusterTemplateInstance resource|
+

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -66,17 +66,17 @@ spec:
     trap 'rm -f "$KUBECONFIG"' EXIT
     echo "$KUBECONFIG_VALUE" > $KUBECONFIG
 
-    OC=(oc --insecure-skip-tls-verify=$INSECURE_SKIP_TLS_VERIFY)
-    CTI_NAME=$(${OC[*]} create -f cti.yaml -o=jsonpath='{.metadata.name}')
+    OC=(oc --insecure-skip-tls-verify="$INSECURE_SKIP_TLS_VERIFY")
+    CTI_NAME=$("${OC[@]}" create -f cti.yaml -o=jsonpath='{.metadata.name}')
     echo "Created ClusterTemplateInstance $CTI_NAME"
     echo -n $CTI_NAME > $(step.results.clusterName.path)
 
     echo "Waiting for ClusterTemplateInstance to be ready (20m timeout)"
-    if ${OC[*]} wait cti $CTI_NAME --for=jsonpath='{.status.phase}'=Ready --timeout=20m; then
+    if "${OC[@]}" wait cti $CTI_NAME --for=jsonpath='{.status.phase}'=Ready --timeout=20m; then
       echo "Successfully provisioned $CTI_NAME"
       exit 0
     else
-      ${OC[*]} get cti $CTI_NAME -o yaml
+      "${OC[@]}" get cti $CTI_NAME -o yaml
       echo "Failed to provision $CTI_NAME"
       exit 1
     fi

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -30,7 +30,7 @@ spec:
         This should not be set to "true" in a production environment.
   results:
     - name: clusterName
-      description: The name of the generated ClusterTemplateInstance resource 
+      description: The name of the generated ClusterTemplateInstance resource.
   env:
     - name: INSTANCE_TYPE
       value: "$(params.instanceType)"

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -1,0 +1,82 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: eaas-create-ephemeral-cluster-hypershift-aws
+spec:
+  description: >-
+    This StepAction provisions an ephemeral cluster using Hypershift with 3 worker nodes in AWS.
+    It does so by creating a ClusterTemplateInstance in a space on an EaaS cluster.
+  image: registry.redhat.io/openshift4/ose-cli@sha256:15da03b04318bcc842060b71e9dd6d6c2595edb4e8fdd11b0c6781eeb03ca182
+  params:
+    - name: eaasSpaceSecretRef
+      type: string
+      description: Name of a secret containing credentials for accessing an EaaS space.
+    - name: version
+      type: string
+      description: >-
+        The version of OpenShift to install. Container images will be pulled from:
+        `quay.io/openshift-release-dev/ocp-release:${version}-multi`.
+    - name: instanceType
+      type: string
+      default: m6g.large
+      description: >-
+        AWS EC2 instance type for worker nodes.
+        Supported values: `m5.large`, `m5.xlarge`, `m5.2xlarge`, `m6g.large`, `m6g.xlarge`, `m6g.2xlarge`
+    - name: insecureSkipTLSVerify
+      type: string
+      default: "false"
+      description: >-
+        Skip TLS verification when accessing the EaaS hub cluster.
+        This should not be set to "true" in a production environment.
+  results:
+    - name: clusterName
+      description: The name of the generated ClusterTemplateInstance resource 
+  env:
+    - name: INSTANCE_TYPE
+      value: "$(params.instanceType)"
+    - name: VERSION
+      value: "$(params.version)"
+    - name: KUBECONFIG
+      value: /tmp/kubeconfig
+    - name: KUBECONFIG_VALUE
+      valueFrom:
+        secretKeyRef:
+          name: $(params.eaasSpaceSecretRef)
+          key: kubeconfig
+    - name: INSECURE_SKIP_TLS_VERIFY
+      value: "$(params.insecureSkipTLSVerify)"
+  script: |
+    #!/bin/bash
+    set -eo pipefail
+
+    cat <<EOF > cti.yaml
+    apiVersion: clustertemplate.openshift.io/v1alpha1
+    kind: ClusterTemplateInstance
+    metadata:
+      generateName: cluster-
+    spec:
+      clusterTemplateRef: hypershift-aws-cluster
+      parameters:
+        - name: instanceType
+          value: $INSTANCE_TYPE
+        - name: version
+          value: $VERSION
+    EOF
+
+    trap 'rm -f "$KUBECONFIG"' EXIT
+    echo "$KUBECONFIG_VALUE" > $KUBECONFIG
+
+    OC=(oc --insecure-skip-tls-verify=$INSECURE_SKIP_TLS_VERIFY)
+    CTI_NAME=$(${OC[*]} create -f cti.yaml -o=jsonpath='{.metadata.name}')
+    echo "Created ClusterTemplateInstance $CTI_NAME"
+    echo -n $CTI_NAME > $(step.results.clusterName.path)
+
+    echo "Waiting for ClusterTemplateInstance to be ready (20m timeout)"
+    if ${OC[*]} wait cti $CTI_NAME --for=jsonpath='{.status.phase}'=Ready --timeout=20m; then
+      echo "Successfully provisioned $CTI_NAME"
+      exit 0
+    else
+      ${OC[*]} get cti $CTI_NAME -o yaml
+      echo "Failed to provision $CTI_NAME"
+      exit 1
+    fi

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/OWNERS
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- amisstea
+- oamsalem
+- avi-biton
+- yftacherzog
+- hmariset

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/OWNERS
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - amisstea
-- oamsalem
+- omeramsc
 - avi-biton
 - yftacherzog
 - hmariset

--- a/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/README.md
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/README.md
@@ -1,0 +1,17 @@
+# eaas-get-ephemeral-cluster-credentials stepaction
+
+This StepAction queries the EaaS hub cluster to get the kubeconfig for an ephemeral cluster by name. Credentials are stored in a mounted volume that must be provided as a param.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|eaasSpaceSecretRef|Name of a secret containing credentials for accessing an EaaS space.||true|
+|clusterName|The name of a ClusterTemplateInstance.||true|
+|credentials|A volume to which the remote cluster credentials will be written.||true|
+|insecureSkipTLSVerify|Skip TLS verification when accessing the EaaS hub cluster. This should not be set to "true" in a production environment.|false|false|
+
+## Results
+|name|description|
+|---|---|
+|kubeconfig|Relative path to the kubeconfig in the mounted volume|
+

--- a/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: eaas-get-ephemeral-cluster-credentials
+spec:
+  description: >-
+    This StepAction queries the EaaS hub cluster to get the kubeconfig for an ephemeral cluster
+    by name. Credentials are stored in a mounted volume that must be provided as a param.
+  image: registry.redhat.io/openshift4/ose-cli@sha256:15da03b04318bcc842060b71e9dd6d6c2595edb4e8fdd11b0c6781eeb03ca182
+  params:
+    - name: eaasSpaceSecretRef
+      type: string
+      description: Name of a secret containing credentials for accessing an EaaS space.
+    - name: clusterName
+      type: string
+      description: The name of a ClusterTemplateInstance.
+    - name: credentials
+      type: string
+      description: A volume to which the remote cluster credentials will be written.
+    - name: insecureSkipTLSVerify
+      type: string
+      default: "false"
+      description: >-
+        Skip TLS verification when accessing the EaaS hub cluster.
+        This should not be set to "true" in a production environment.
+  results:
+    - name: kubeconfig
+      description: Relative path to the kubeconfig in the mounted volume
+  env:
+    - name: CLUSTER_NAME
+      value: "$(params.clusterName)"
+    - name: CLUSTER_KUBECONFIG
+      value: "/credentials/$(params.clusterName)-kubeconfig"
+    - name: KUBECONFIG
+      value: /tmp/eaas-kubeconfig
+    - name: KUBECONFIG_VALUE
+      valueFrom:
+        secretKeyRef:
+          name: $(params.eaasSpaceSecretRef)
+          key: kubeconfig
+    - name: INSECURE_SKIP_TLS_VERIFY
+      value: "$(params.insecureSkipTLSVerify)"
+  volumeMounts:
+    - name: "$(params.credentials)"
+      mountPath: /credentials
+  script: |
+    #!/bin/bash
+    set -eo pipefail
+
+    trap 'rm -f "$KUBECONFIG"' EXIT
+    echo "$KUBECONFIG_VALUE" > $KUBECONFIG
+
+    OC=(oc --insecure-skip-tls-verify=$INSECURE_SKIP_TLS_VERIFY)
+    SECRET=$(${OC[*]} get cti $CLUSTER_NAME -o=jsonpath='{.status.kubeconfig.name}')
+    echo "Found kubeconfig secret: $SECRET"
+    ${OC[*]} get secret $SECRET -o go-template --template="{{.data.kubeconfig|base64decode}}" > $CLUSTER_KUBECONFIG
+    echo "Wrote kubeconfig to $CLUSTER_KUBECONFIG"
+    echo -n $(basename $CLUSTER_KUBECONFIG) > $(step.results.kubeconfig.path)

--- a/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
@@ -50,9 +50,9 @@ spec:
     trap 'rm -f "$KUBECONFIG"' EXIT
     echo "$KUBECONFIG_VALUE" > $KUBECONFIG
 
-    OC=(oc --insecure-skip-tls-verify=$INSECURE_SKIP_TLS_VERIFY)
-    SECRET=$(${OC[*]} get cti $CLUSTER_NAME -o=jsonpath='{.status.kubeconfig.name}')
+    OC=(oc --insecure-skip-tls-verify="$INSECURE_SKIP_TLS_VERIFY")
+    SECRET=$("${OC[@]}" get cti $CLUSTER_NAME -o=jsonpath='{.status.kubeconfig.name}')
     echo "Found kubeconfig secret: $SECRET"
-    ${OC[*]} get secret $SECRET -o go-template --template="{{.data.kubeconfig|base64decode}}" > $CLUSTER_KUBECONFIG
+    "${OC[@]}" get secret $SECRET -o go-template --template="{{.data.kubeconfig|base64decode}}" > $CLUSTER_KUBECONFIG
     echo "Wrote kubeconfig to $CLUSTER_KUBECONFIG"
     echo -n $(basename $CLUSTER_KUBECONFIG) > $(step.results.kubeconfig.path)

--- a/stepactions/eaas-get-ephemeral-cluster-credentials/OWNERS
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- amisstea
+- oamsalem
+- avi-biton
+- yftacherzog
+- hmariset

--- a/stepactions/eaas-get-ephemeral-cluster-credentials/OWNERS
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - amisstea
-- oamsalem
+- omeramsc
 - avi-biton
 - yftacherzog
 - hmariset

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/README.md
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/README.md
@@ -1,0 +1,15 @@
+# eaas-get-latest-openshift-version-by-prefix stepaction
+
+This StepAction queries an OpenShift CI API to get the latest version for a release stream.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|prefix|The leading part of the OpenShift version. E.g. `4.` or `4.15.`||true|
+|releaseStream|The name of the OpenShift release stream. E.g. `4-stable`|4-stable|false|
+
+## Results
+|name|description|
+|---|---|
+|version|The latest matching version.|
+

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
@@ -28,4 +28,4 @@ spec:
     echo "GET $URL"
     RESULT=$(curl -s -L -H "Accepts: application/json" $URL)
     echo "$RESULT"
-    echo "$RESULT" | jq -j '.name' > $(step.results.version.path)
+    jq -j '.name' <<< "$RESULT" > $(step.results.version.path)

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
@@ -26,6 +26,6 @@ spec:
     set -eo pipefail
 
     echo "GET $URL"
-    RESULT=$(curl -s -L -H "Accepts: application/json" $URL)
+    RESULT=$(curl -f -s -L -H "Accepts: application/json" $URL)
     echo "$RESULT"
     jq -j '.name' <<< "$RESULT" > $(step.results.version.path)

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: eaas-get-latest-openshift-version-by-prefix
+spec:
+  description: >-
+    This StepAction queries an OpenShift CI API to get the latest version for a release stream.
+  image: quay.io/redhat-appstudio/appstudio-utils@sha256:586149e3f18d966f681d956ab074b4e1d8433663d615ed86e19a3804ba952dfe
+  params:
+    - name: prefix
+      type: string
+      description: The leading part of the OpenShift version. E.g. `4.` or `4.15.`
+    - name: releaseStream
+      type: string
+      default: 4-stable
+      description: The name of the OpenShift release stream. E.g. `4-stable`
+  results:
+    - name: version
+      description: The latest matching version.
+  env:
+    - name: URL
+      value: https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/$(params.releaseStream)/latest?prefix=$(params.prefix)
+  script: |
+    #!/bin/bash
+    set -eo pipefail
+
+    echo "GET $URL"
+    RESULT=$(curl -s -L -H "Accepts: application/json" $URL)
+    echo "$RESULT"
+    echo "$RESULT" | jq -j '.name' > $(step.results.version.path)

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/OWNERS
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- amisstea
+- oamsalem
+- avi-biton
+- yftacherzog
+- hmariset

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/OWNERS
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - amisstea
-- oamsalem
+- omeramsc
 - avi-biton
 - yftacherzog
 - hmariset

--- a/stepactions/eaas-get-supported-ephemeral-cluster-versions/OWNERS
+++ b/stepactions/eaas-get-supported-ephemeral-cluster-versions/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - amisstea
-- oamsalem
+- omeramsc
 - avi-biton
 - yftacherzog
 - hmariset

--- a/task/build-image-manifest/0.1/README.md
+++ b/task/build-image-manifest/0.1/README.md
@@ -1,6 +1,6 @@
 # build-image-manifest task
 
-This task generates an image manifest from a collection of existing single platform images to create a multi-platform image.
+This task generates an image index from a collection of existing single platform images to create a multi-platform image.
 
 ## Parameters
 | name                | description                                                                                                                                                        |default value|required|

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -79,7 +79,7 @@ spec:
           TOADD="$(echo $i | cut -d: -f1)@sha256:$(echo $i | cut -d: -f3)"
         fi
         echo "Adding $TOADD"
-        buildah manifest add $IMAGE "docker://$TOADD"
+        buildah manifest add $IMAGE "docker://$TOADD" --all
       done
 
       status=-1

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -42,6 +42,8 @@ spec:
     volumeMounts:
       - mountPath: "/var/workdir"
         name: workdir
+      - mountPath: "/var/lib/containers/storage"
+        name: varlibcontainers
   steps:
     - name: use-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
@@ -217,6 +219,8 @@ spec:
   volumes:
     - emptyDir: {}
       name: workdir
+    - emptyDir: {}
+      name: varlibcontainers
     - name: ssh
       secret:
         optional: false

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -221,3 +221,7 @@ spec:
       secret:
         optional: false
         secretName: multi-platform-ssh-$(context.taskRun.name)
+    - name: etc-pki-entitlement
+      secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -223,5 +223,5 @@ spec:
         secretName: multi-platform-ssh-$(context.taskRun.name)
     - name: etc-pki-entitlement
       secret:
-      optional: true
-      secretName: $(params.ENTITLEMENT_SECRET)
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -112,7 +112,7 @@ spec:
 
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
 
-        # form the --type arguments 
+        # form the --type arguments
         IMAGE_TYPES=" --type $IMAGE_TYPE "
 
         # this heredoc allows expansions for the image name
@@ -182,7 +182,7 @@ spec:
 
 
         # make scripts executable and sync them to the cloud VM.
-        
+
         chmod +x scripts/script-build.sh
         chmod +x scripts/script-push.sh
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -22,7 +22,7 @@ spec:
     - default: etc-pki-entitlement
       description: Name of secret which contains the entitlement certificates
       name: ENTITLEMENT_SECRET
-      type: string 
+      type: string
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST
@@ -135,7 +135,7 @@ spec:
         set -e
 
         # this prevents the container from using podman-subscripition-mananger magic,
-        # so that it will use certificates from /etc/pki/entitlements 
+        # so that it will use certificates from /etc/pki/entitlements
         sudo rm /usr/share/containers/mounts.conf
 
         export BUILD_DIR="$BUILD_DIR"

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -105,7 +105,7 @@ spec:
         chmod 0400 ~/.ssh/id_rsa
         export SSH_HOST=$(cat /ssh/host)
         export BUILD_DIR=$(cat /ssh/user-dir)
-        export SSH_ARGS="-o StrictHostKeyChecking=no"
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=180"
         mkdir -p scripts
         echo "$BUILD_DIR"
         ssh -v $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -156,7 +156,7 @@ spec:
         #!/bin/bash
         set -e
         dnf -y install buildah
-        buildah manifest create "$OUTPUT_IMAGE"
+        buildah --storage-driver=vfs manifest create "$OUTPUT_IMAGE"
 
         # show contents of /output
         ls -alR /output
@@ -164,17 +164,17 @@ spec:
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
           gzip /output/qcow2/disk.qcow2
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2.gz
+          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2.gz
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
           gzip /output/image/disk.raw
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
         elif [ -f "/output/bootiso/install.iso" ]; then
           echo -e "Found iso image."
           gzip /output/bootiso/install.iso
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
         fi
-        buildah manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
+        buildah --storage-driver=vfs manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
         echo -n "$OUTPUT_IMAGE" | tee /tekton-results/IMAGE_URL
         cat image-digest | tee /tekton-results/IMAGE_DIGEST
         REMOTESSHEOF

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -1,6 +1,12 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, appstudio, hacbs
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: disk-image
   name: build-vm-image
 spec:
   params:

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -105,7 +105,7 @@ spec:
         chmod 0400 ~/.ssh/id_rsa
         export SSH_HOST=$(cat /ssh/host)
         export BUILD_DIR=$(cat /ssh/user-dir)
-        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=180"
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60"
         mkdir -p scripts
         echo "$BUILD_DIR"
         ssh -v $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"
@@ -128,6 +128,9 @@ spec:
 
         REMOTESSHEOF
 
+        # just gathering some info
+        cat /etc/fstab
+        mount
 
         # no expansions in this one, the env vars are evaluated on the remote vm
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
@@ -157,7 +160,7 @@ spec:
         cat >scripts/script-push.sh <<REMOTESSHEOF
         #!/bin/bash
         set -ex
-        dnf -y install buildah
+        dnf -y install buildah pigz
         buildah --storage-driver=vfs manifest create "$OUTPUT_IMAGE"
 
         # show contents of /output
@@ -165,15 +168,15 @@ spec:
 
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
-          gzip /output/qcow2/disk.qcow2
+          pigz /output/qcow2/disk.qcow2
           buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2.gz
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
-          gzip /output/image/disk.raw
+          pigz /output/image/disk.raw
           buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
         elif [ -f "/output/bootiso/install.iso" ]; then
           echo -e "Found iso image."
-          gzip /output/bootiso/install.iso
+          pigz /output/bootiso/install.iso
           buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
         fi
         buildah --storage-driver=vfs manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -128,9 +128,6 @@ spec:
 
         REMOTESSHEOF
 
-        # just gathering some info
-        mount
-
         # no expansions in this one, the env vars are evaluated on the remote vm
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
         echo >config.toml <<EOF
@@ -185,6 +182,10 @@ spec:
 
 
         # make scripts executable and sync them to the cloud VM.
+        
+        # TEMP just gathering some info
+        mount
+        
         chmod +x scripts/script-build.sh
         chmod +x scripts/script-push.sh
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -160,7 +160,7 @@ spec:
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
           -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output \
           -v /var/lib/containers/storage:/var/lib/containers/storage \
-          -v /etc/pki/entitlement:/etc/pki/entitlement:Z \
+          -v /entitlement:/etc/pki/entitlement:Z \
           $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
 
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
@@ -211,6 +211,8 @@ spec:
         - mountPath: /ssh
           name: ssh
           readOnly: true
+        - mountPath: /entitlement
+          name: etc-pki-entitlement
 
   volumes:
     - emptyDir: {}

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -130,7 +130,7 @@ spec:
 
         # this prevents the container from using podman-subscripition-mananger magic,
         # so that it will use certificates from /etc/pki/entitlements 
-        sudo podman run -v /usr/share/containers:/usr/share/containers:Z -it registry.redhat.io/ubi9/ubi  rm /usr/share/containers/mounts.conf
+        sudo rm /usr/share/containers/mounts.conf
 
         export BUILD_DIR="$BUILD_DIR"
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -9,6 +9,7 @@ metadata:
     build.appstudio.redhat.com/build_type: disk-image
   name: build-vm-image
 spec:
+  description: "Build disk images using bootc-image-builder. https://github.com/osbuild/bootc-image-builder/"
   params:
     - description: The platform to build on
       name: PLATFORM

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -64,16 +64,19 @@ spec:
         # # BIB: Bootc Image Builder config
         # bootc-builder-image: "quay.io/centos-bootc/bootc-image-builder:latest"
         # source-image: "quay.io/centos-bootc/centos-bootc:stream9"
+        # tagged-as: registry.centos.org/bootc:stream9
 
         # trim any leading slash.
         BIB_CONFIG_FILE=${BIB_CONFIG_FILE#/}
 
         BIB_IMAGE=$(yq -r .bootc-builder-image /var/workdir/source/$BIB_CONFIG_FILE)
         SOURCE_IMAGE=$(yq -r  .source-image /var/workdir/source/$BIB_CONFIG_FILE)
+        TAGGED_AS=$(yq -r  ".tagged-as // \"${SOURCE_IMAGE}\"" /var/workdir/source/$BIB_CONFIG_FILE)
 
         # write values to a file in the workspace
         echo "declare BOOTC_BUILDER_IMAGE=${BIB_IMAGE}" > /var/workdir/vars
         echo "declare SOURCE_IMAGE=${SOURCE_IMAGE}" >> /var/workdir/vars
+        echo "declare TAGGED_AS=${TAGGED_AS}" >> /var/workdir/vars
 
         # here we should validate that both keys exist and are valid pullspecs.
         # todo
@@ -99,6 +102,7 @@ spec:
         echo "Vars:"
         echo BOOTC_BUILDER_IMAGE $BOOTC_BUILDER_IMAGE
         echo SOURCE_IMAGE $SOURCE_IMAGE
+        echo TAGGED_AS $TAGGED_AS
 
         mkdir -p ~/.ssh
         if [ -e "/ssh/error" ]; then
@@ -138,6 +142,7 @@ spec:
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
         export BOOTC_BUILDER_IMAGE="$BOOTC_BUILDER_IMAGE"
         export SOURCE_IMAGE="$SOURCE_IMAGE"
+        export TAGGED_AS="$TAGGED_AS"
         export IMAGE_TYPES="$IMAGE_TYPES"
 
         REMOTESSHEOF
@@ -156,6 +161,8 @@ spec:
         time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json $BOOTC_BUILDER_IMAGE
         echo "PULLING IMAGE"
         time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json $SOURCE_IMAGE
+        echo "TAGGING IMAGE"
+        time sudo podman tag $SOURCE_IMAGE $TAGGED_AS
         echo "RUNNING BUILD"
         echo -e "IMAGE_TYPES = $IMAGE_TYPES"
 
@@ -163,7 +170,7 @@ spec:
           -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output \
           -v /var/lib/containers/storage:/var/lib/containers/storage \
           -v $BUILD_DIR/entitlement:/etc/pki/entitlement:Z \
-          $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
+          $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $TAGGED_AS
 
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -129,7 +129,6 @@ spec:
         REMOTESSHEOF
 
         # just gathering some info
-        cat /etc/fstab
         mount
 
         # no expansions in this one, the env vars are evaluated on the remote vm

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -166,7 +166,12 @@ spec:
           $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
 
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
-        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh -v $BUILD_DIR/tekton-results:/tekton-results registry.fedoraproject.org/fedora /script-push.sh
+        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
+          -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output \
+          -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh \
+          -v $BUILD_DIR/tekton-results:/tekton-results \
+          registry.fedoraproject.org/fedora \
+          /script-push.sh
 
         REMOTESSHEOF
 

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -36,6 +36,9 @@ spec:
         value: $(params.BIB_CONFIG_FILE)
       - name: IMAGE_TYPE
         value: $(params.IMAGE_TYPE)
+      - name: ENTITLEMENT_SECRET
+        value: $(params.ENTITLEMENT_SECRET)
+
     volumeMounts:
       - mountPath: "/var/workdir"
         name: workdir
@@ -115,6 +118,11 @@ spec:
         ssh -v $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"
 
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+
+        # this prevents the container from using podman-subscripition-mananger magic,
+        # so that it will use certificates from /etc/pki/entitlements 
+        sudo podman run -v /usr/share/containers:/usr/share/containers:Z -it registry.redhat.io/ubi9/ubi  rm /usr/share/containers/mounts.conf
 
         # form the --type arguments
         IMAGE_TYPES=" --type $IMAGE_TYPE "
@@ -149,7 +157,11 @@ spec:
         echo "RUNNING BUILD"
         echo -e "IMAGE_TYPES = $IMAGE_TYPES"
 
-        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output -v /var/lib/containers/storage:/var/lib/containers/storage $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
+        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
+          -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output \
+          -v /var/lib/containers/storage:/var/lib/containers/storage \
+          -v /etc/pki/entitlement:/etc/pki/entitlement:Z \
+          $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
 
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh -v $BUILD_DIR/tekton-results:/tekton-results registry.fedoraproject.org/fedora /script-push.sh

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -164,8 +164,8 @@ spec:
 
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
-          pigz /output/qcow2/disk.qcow2
-          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2.gz
+          # don't zip qcow2 images, it is already compressed.
+          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
           pigz /output/image/disk.raw
@@ -182,9 +182,6 @@ spec:
 
 
         # make scripts executable and sync them to the cloud VM.
-        
-        # TEMP just gathering some info
-        mount
         
         chmod +x scripts/script-build.sh
         chmod +x scripts/script-push.sh

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -42,7 +42,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: validate-bib-config
-      image: quay.io/redhat-user-workloads/rhtap-integration-tenant/yq-container/yq:99301602bc9ea9c909df5903d848e5fb582598de
+      image: quay.io/konflux-ci/yq@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       script: |-
         #!/bin/bash
         set -o verbose
@@ -91,7 +91,7 @@ spec:
         echo BOOTC_BUILDER_IMAGE $BOOTC_BUILDER_IMAGE
         echo SOURCE_IMAGE $SOURCE_IMAGE
 
-        mkdir -p ~/.ssh 
+        mkdir -p ~/.ssh
         if [ -e "/ssh/error" ]; then
           #no server could be provisioned
           cat /ssh/error

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -168,6 +168,7 @@ spec:
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
           -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output \
+          -v /var/lib/containers/storage:/var/lib/containers/storage \
           -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh \
           -v $BUILD_DIR/tekton-results:/tekton-results \
           registry.fedoraproject.org/fedora \

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -120,10 +120,6 @@ spec:
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
         rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/entitlement/"
 
-        # this prevents the container from using podman-subscripition-mananger magic,
-        # so that it will use certificates from /etc/pki/entitlements 
-        sudo podman run -v /usr/share/containers:/usr/share/containers:Z -it registry.redhat.io/ubi9/ubi  rm /usr/share/containers/mounts.conf
-
         # form the --type arguments
         IMAGE_TYPES=" --type $IMAGE_TYPE "
 
@@ -131,6 +127,10 @@ spec:
         cat >scripts/script-build.sh <<REMOTESSHEOF
         #!/bin/sh
         set -e
+
+        # this prevents the container from using podman-subscripition-mananger magic,
+        # so that it will use certificates from /etc/pki/entitlements 
+        sudo podman run -v /usr/share/containers:/usr/share/containers:Z -it registry.redhat.io/ubi9/ubi  rm /usr/share/containers/mounts.conf
 
         export BUILD_DIR="$BUILD_DIR"
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -16,7 +16,7 @@ spec:
       type: string
     - name: OUTPUT_IMAGE
       type: string
-      description: The output manifest list that points to the OCI artifact of the zipped ZM image
+      description: The output manifest list that points to the OCI artifact of the zipped image
     - name: SOURCE_ARTIFACT
       type: string
     - name: IMAGE_TYPE

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -19,6 +19,10 @@ spec:
       default: bib.yaml
       type: string
       description: The config file specifying what to build and the builder to build it with
+    - default: etc-pki-entitlement
+      description: Name of secret which contains the entitlement certificates
+      name: ENTITLEMENT_SECRET
+      type: string 
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -115,10 +115,10 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60"
         mkdir -p scripts
         echo "$BUILD_DIR"
-        ssh -v $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"
+        ssh -v $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results" "$BUILD_DIR/entitlement"
 
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
-        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/entitlement/"
 
         # this prevents the container from using podman-subscripition-mananger magic,
         # so that it will use certificates from /etc/pki/entitlements 
@@ -160,7 +160,7 @@ spec:
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
           -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output \
           -v /var/lib/containers/storage:/var/lib/containers/storage \
-          -v /entitlement:/etc/pki/entitlement:Z \
+          -v $BUILD_DIR/entitlement:/etc/pki/entitlement:Z \
           $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
 
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -80,13 +80,25 @@ spec:
         SOURCE_IMAGE=$(yq -r  .source-image /var/workdir/source/$BIB_CONFIG_FILE)
         TAGGED_AS=$(yq -r  ".tagged-as // \"${SOURCE_IMAGE}\"" /var/workdir/source/$BIB_CONFIG_FILE)
 
+        # Validate that all keys exist and are plausible pullspecs
+        valid='0-9a-zA-Z@:/'
+        if [[ "${BIB_IMAGE}" =~ [^$pullspec]  ]]; do
+          echo ".bootc-builder-image in $BIB_CONFIG_FILE doesn't match $valid"
+          exit 1
+        done
+        if [[ "${SOURCE_IMAGE}" =~ [^$pullspec]  ]]; do
+          echo ".source-image in $BIB_CONFIG_FILE doesn't match $valid"
+          exit 1
+        done
+        if [[ "${TAGGED_AS}" =~ [^$pullspec]  ]]; do
+          echo ".tagged-as in $BIB_CONFIG_FILE doesn't match $valid"
+          exit 1
+        done
+
         # write values to a file in the workspace
         echo "declare BOOTC_BUILDER_IMAGE=${BIB_IMAGE}" > /var/workdir/vars
         echo "declare SOURCE_IMAGE=${SOURCE_IMAGE}" >> /var/workdir/vars
         echo "declare TAGGED_AS=${TAGGED_AS}" >> /var/workdir/vars
-
-        # here we should validate that both keys exist and are valid pullspecs.
-        # todo
 
     - name: build
       image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -1,0 +1,203 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-vm-image
+spec:
+  params:
+    - description: The platform to build on
+      name: PLATFORM
+      type: string
+    - name: OUTPUT_IMAGE
+      type: string
+      description: The output manifest list that points to the OCI artifact of the zipped ZM image
+    - name: SOURCE_ARTIFACT
+      type: string
+    - name: IMAGE_TYPE
+      type: string
+      description: The type of VM image to build, valid values are iso, qcow2 and raw
+    - name: BIB_CONFIG_FILE
+      default: bib.yaml
+      type: string
+      description: The config file specifying what to build and the builder to build it with
+  results:
+    - description: Digest of the manifest list just built
+      name: IMAGE_DIGEST
+    - description: Image repository where the built manifest list was pushed
+      name: IMAGE_URL
+  stepTemplate:
+    env:
+      - name: OUTPUT_IMAGE
+        value: $(params.OUTPUT_IMAGE)
+      - name: BIB_CONFIG_FILE
+        value: $(params.BIB_CONFIG_FILE)
+      - name: IMAGE_TYPE
+        value: $(params.IMAGE_TYPE)
+    volumeMounts:
+      - mountPath: "/var/workdir"
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: validate-bib-config
+      image: quay.io/redhat-user-workloads/rhtap-integration-tenant/yq-container/yq:99301602bc9ea9c909df5903d848e5fb582598de
+      script: |-
+        #!/bin/bash
+        set -o verbose
+        set -e
+
+        # expects a config file like the following as BIB_CONFIG_FILE
+        #
+        echo -e "BIB_CONFIG_FILE: $BIB_CONFIG_FILE"
+        # # BIB: Bootc Image Builder config
+        # bootc-builder-image: "quay.io/centos-bootc/bootc-image-builder:latest"
+        # source-image: "quay.io/centos-bootc/centos-bootc:stream9"
+
+        # trim any leading slash.
+        BIB_CONFIG_FILE=${BIB_CONFIG_FILE#/}
+
+        BIB_IMAGE=$(yq -r .bootc-builder-image /var/workdir/source/$BIB_CONFIG_FILE)
+        SOURCE_IMAGE=$(yq -r  .source-image /var/workdir/source/$BIB_CONFIG_FILE)
+
+        # write values to a file in the workspace
+        echo "declare BOOTC_BUILDER_IMAGE=${BIB_IMAGE}" > /var/workdir/vars
+        echo "declare SOURCE_IMAGE=${SOURCE_IMAGE}" >> /var/workdir/vars
+
+        # here we should validate that both keys exist and are valid pullspecs.
+        # todo
+
+    - name: build
+      image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      script: |-
+        #!/bin/bash
+        set -o verbose
+        set -eu
+
+        # get values stored from previous task
+        echo "vars file"
+        cat /var/workdir/vars
+        source /var/workdir/vars
+        echo "Vars:"
+        echo BOOTC_BUILDER_IMAGE $BOOTC_BUILDER_IMAGE
+        echo SOURCE_IMAGE $SOURCE_IMAGE
+
+        mkdir -p ~/.ssh 
+        if [ -e "/ssh/error" ]; then
+          #no server could be provisioned
+          cat /ssh/error
+          exit 1
+        elif [ -e "/ssh/otp" ]; then
+          curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+          echo "" >> ~/.ssh/id_rsa
+        else
+          cp /ssh/id_rsa ~/.ssh
+        fi
+        chmod 0400 ~/.ssh/id_rsa
+        export SSH_HOST=$(cat /ssh/host)
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no"
+        mkdir -p scripts
+        echo "$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"
+
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+
+        # form the --type arguments 
+        IMAGE_TYPES=" --type $IMAGE_TYPE "
+
+        # this heredoc allows expansions for the image name
+        cat >scripts/script-build.sh <<REMOTESSHEOF
+        #!/bin/sh
+        set -e
+
+        export BUILD_DIR="$BUILD_DIR"
+        export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+        export BOOTC_BUILDER_IMAGE="$BOOTC_BUILDER_IMAGE"
+        export SOURCE_IMAGE="$SOURCE_IMAGE"
+        export IMAGE_TYPES="$IMAGE_TYPES"
+
+        REMOTESSHEOF
+
+
+        # no expansions in this one, the env vars are evaluated on the remote vm
+        cat >>scripts/script-build.sh <<'REMOTESSHEOF'
+        echo >config.toml <<EOF
+        [[blueprint.customizations.user]]
+        name = "user"
+        password = "pass"
+        groups = ["wheel"]
+        EOF
+
+        mkdir output
+        echo "PULLING BUILDER IMAGE"
+        time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json $BOOTC_BUILDER_IMAGE
+        echo "PULLING IMAGE"
+        time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json $SOURCE_IMAGE
+        echo "RUNNING BUILD"
+        echo -e "IMAGE_TYPES = $IMAGE_TYPES"
+
+        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output -v /var/lib/containers/storage:/var/lib/containers/storage $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $SOURCE_IMAGE
+
+        # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
+        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh -v $BUILD_DIR/tekton-results:/tekton-results registry.fedoraproject.org/fedora /script-push.sh
+
+        REMOTESSHEOF
+
+        # script-push.sh script is intended run _inside_ podman on the ssh host and requires sudo
+        cat >scripts/script-push.sh <<REMOTESSHEOF
+        #!/bin/bash
+        set -e
+        dnf -y install buildah
+        buildah manifest create "$OUTPUT_IMAGE"
+
+        # show contents of /output
+        ls -alR /output
+
+        if [ -f "/output/qcow2/disk.qcow2" ]; then
+          echo -e "Found qcow2 image."
+          gzip /output/qcow2/disk.qcow2
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2.gz
+        elif [ -f "/output/image/disk.raw" ]; then
+          echo -e "Found raw image."
+          gzip /output/image/disk.raw
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+        elif [ -f "/output/bootiso/install.iso" ]; then
+          echo -e "Found iso image."
+          gzip /output/bootiso/install.iso
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+        fi
+        buildah manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
+        echo -n "$OUTPUT_IMAGE" | tee /tekton-results/IMAGE_URL
+        cat image-digest | tee /tekton-results/IMAGE_DIGEST
+        REMOTESSHEOF
+
+
+        # make scripts executable and sync them to the cloud VM.
+        chmod +x scripts/script-build.sh
+        chmod +x scripts/script-push.sh
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        rsync -ra /var/workdir/source/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+
+        ssh $SSH_ARGS "$SSH_HOST" $BUILD_DIR/scripts/script-build.sh
+        rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
+
+      volumeMounts:
+        - mountPath: /ssh
+          name: ssh
+          readOnly: true
+
+  volumes:
+    - emptyDir: {}
+      name: workdir
+    - name: ssh
+      secret:
+        optional: false
+        secretName: multi-platform-ssh-$(context.taskRun.name)

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -47,6 +47,7 @@ spec:
         #!/bin/bash
         set -o verbose
         set -e
+        set -x
 
         # expects a config file like the following as BIB_CONFIG_FILE
         #
@@ -80,6 +81,7 @@ spec:
         #!/bin/bash
         set -o verbose
         set -eu
+        set -x
 
         # get values stored from previous task
         echo "vars file"
@@ -106,7 +108,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no"
         mkdir -p scripts
         echo "$BUILD_DIR"
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"
+        ssh -v $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results"
 
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
 
@@ -154,7 +156,7 @@ spec:
         # script-push.sh script is intended run _inside_ podman on the ssh host and requires sudo
         cat >scripts/script-push.sh <<REMOTESSHEOF
         #!/bin/bash
-        set -e
+        set -ex
         dnf -y install buildah
         buildah --storage-driver=vfs manifest create "$OUTPUT_IMAGE"
 
@@ -186,7 +188,7 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         rsync -ra /var/workdir/source/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
 
-        ssh $SSH_ARGS "$SSH_HOST" $BUILD_DIR/scripts/script-build.sh
+        ssh -v $SSH_ARGS "$SSH_HOST" $BUILD_DIR/scripts/script-build.sh
         rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
 
       volumeMounts:

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -20,6 +20,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -20,7 +20,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -8,6 +8,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
@@ -20,7 +21,6 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -23,8 +23,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
-|SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|
-|SQUASH_ALL|Squash all new and previous layers added as a part of this build, as per --squash-all|false|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -22,6 +22,8 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|
+|SQUASH_ALL|Squash all new and previous layers added as a part of this build, as per --squash-all|false|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -20,7 +20,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|""|false|
+|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -76,6 +76,16 @@ spec:
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
       type: string
+    - name: SQUASH
+      description: Squash new layers added as a part of this build, as per
+        --squash
+      type: string
+      default: "false"
+    - name: SQUASH_ALL
+      description: Squash all new and previous layers added as a part of this
+        build, as per --squash-all
+      type: string
+      default: "false"
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.
@@ -158,6 +168,10 @@ spec:
         value: $(params.IMAGE)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: SQUASH
+        value: $(params.SQUASH)
+      - name: SQUASH_ALL
+        value: $(params.SQUASH_ALL)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -269,6 +283,14 @@ spec:
 
         if [ -n "${ADD_CAPABILITIES}" ]; then
           BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+        fi
+
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        if [ "${SQUASH_ALL}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash-all")
         fi
 
         if [ -f "/var/workdir/cachi2/cachi2.env" ]; then

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -67,6 +67,11 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
+    - name: OPTIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+      type: string
+      default: ""
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.
@@ -135,6 +140,10 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
+    - name: optional-secret
+      secret:
+        optional: true
+        secretName: $(params.OPTIONAL_SECRET)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -172,6 +181,8 @@ spec:
         value: $(params.SQUASH)
       - name: SQUASH_ALL
         value: $(params.SQUASH_ALL)
+      - name: OPTIONAL_SECRET
+        value: $(params.OPTIONAL_SECRET)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -206,6 +217,8 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
+        - mountPath: /optional-secret
+          name: optional-secret
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
@@ -334,6 +347,13 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
+        fi
+
+        OPTIONAL_SECRET_PATH="/optional-secret"
+        if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+          BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+          echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
         fi
 
         unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -342,10 +342,10 @@ spec:
         ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
         if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
           cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
-          for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+          while read -r filename; do
             echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
             BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
-          done
+          done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
         fi
 
         unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -498,7 +498,13 @@ spec:
         container=$(buildah from --pull-never $IMAGE)
         buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
         buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-        buildah commit $container $IMAGE
+
+        BUILDAH_ARGS=()
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
         status=-1
         max_run=5

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -339,10 +339,13 @@ spec:
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"
+        ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
         if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
-          cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
-          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
-          echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
+          cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+          for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+            echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+            BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+          done
         fi
 
         unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -71,7 +71,7 @@ spec:
       description: Name of a secret which will be made available to the build
         with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
       type: string
-      default: ""
+      default: does-not-exist
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -67,9 +67,9 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
-    - name: OPTIONAL_SECRET
+    - name: ADDITIONAL_SECRET
       description: Name of a secret which will be made available to the build
-        with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
       type: string
       default: does-not-exist
     - name: PREFETCH_INPUT
@@ -140,10 +140,10 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
-    - name: optional-secret
+    - name: additional-secret
       secret:
         optional: true
-        secretName: $(params.OPTIONAL_SECRET)
+        secretName: $(params.ADDITIONAL_SECRET)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -181,8 +181,8 @@ spec:
         value: $(params.SQUASH)
       - name: SQUASH_ALL
         value: $(params.SQUASH_ALL)
-      - name: OPTIONAL_SECRET
-        value: $(params.OPTIONAL_SECRET)
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -217,8 +217,8 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
-        - mountPath: /optional-secret
-          name: optional-secret
+        - mountPath: /additional-secret
+          name: additional-secret
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
@@ -349,11 +349,11 @@ spec:
           echo "Adding the entitlement to the build"
         fi
 
-        OPTIONAL_SECRET_PATH="/optional-secret"
-        if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-          cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-          BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-          echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+        ADDITIONAL_SECRET_PATH="/additional-secret"
+        if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+          echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
         fi
 
         unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -16,6 +16,11 @@ spec:
     When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
     When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
+    - name: ADDITIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
+      type: string
+      default: does-not-exist
     - name: ADD_CAPABILITIES
       description: Comma separated list of extra capabilities to add when
         running 'buildah build'
@@ -67,11 +72,6 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
-    - name: ADDITIONAL_SECRET
-      description: Name of a secret which will be made available to the build
-        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
-      type: string
-      default: does-not-exist
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.
@@ -136,14 +136,14 @@ spec:
       description: The counting of Java components by publisher in JSON format
       type: string
   volumes:
-    - name: etc-pki-entitlement
-      secret:
-        optional: true
-        secretName: $(params.ENTITLEMENT_SECRET)
     - name: additional-secret
       secret:
         optional: true
         secretName: $(params.ADDITIONAL_SECRET)
+    - name: etc-pki-entitlement
+      secret:
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -159,6 +159,8 @@ spec:
       emptyDir: {}
   stepTemplate:
     env:
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
       - name: BUILDAH_FORMAT
@@ -181,8 +183,6 @@ spec:
         value: $(params.SQUASH)
       - name: SQUASH_ALL
         value: $(params.SQUASH_ALL)
-      - name: ADDITIONAL_SECRET
-        value: $(params.ADDITIONAL_SECRET)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -416,7 +416,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: merge-cachi2-sbom
-      image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+      image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
       workingDir: /var/workdir
       script: |
         if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -82,13 +82,8 @@ spec:
         the application source code.
       type: string
     - name: SQUASH
-      description: Squash new layers added as a part of this build, as per
-        --squash
-      type: string
-      default: "false"
-    - name: SQUASH_ALL
       description: Squash all new and previous layers added as a part of this
-        build, as per --squash-all
+        build, as per --squash
       type: string
       default: "false"
     - name: TARGET_STAGE
@@ -181,8 +176,6 @@ spec:
         value: $(params.IMAGE_EXPIRES_AFTER)
       - name: SQUASH
         value: $(params.SQUASH)
-      - name: SQUASH_ALL
-        value: $(params.SQUASH_ALL)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -300,10 +293,6 @@ spec:
 
         if [ "${SQUASH}" == "true" ]; then
           BUILDAH_ARGS+=("--squash")
-        fi
-
-        if [ "${SQUASH_ALL}" == "true" ]; then
-          BUILDAH_ARGS+=("--squash-all")
         fi
 
         if [ -f "/var/workdir/cachi2/cachi2.env" ]; then

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -486,7 +486,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     name: merge-cachi2-sbom
     script: |
       if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -359,10 +359,10 @@ spec:
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
         cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
-        for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+        while read -r filename; do
           echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
           BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
-        done
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -568,7 +568,13 @@ spec:
       container=$(buildah from --pull-never $IMAGE)
       buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-      buildah commit $container $IMAGE
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
       status=-1
       max_run=5

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -82,13 +82,9 @@ spec:
     name: SOURCE_ARTIFACT
     type: string
   - default: "false"
-    description: Squash new layers added as a part of this build, as per --squash
-    name: SQUASH
-    type: string
-  - default: "false"
     description: Squash all new and previous layers added as a part of this build,
-      as per --squash-all
-    name: SQUASH_ALL
+      as per --squash
+    name: SQUASH
     type: string
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
@@ -160,8 +156,6 @@ spec:
       value: $(params.IMAGE_EXPIRES_AFTER)
     - name: SQUASH
       value: $(params.SQUASH)
-    - name: SQUASH_ALL
-      value: $(params.SQUASH_ALL)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -318,10 +312,6 @@ spec:
         BUILDAH_ARGS+=("--squash")
       fi
 
-      if [ "${SQUASH_ALL}" == "true" ]; then
-        BUILDAH_ARGS+=("--squash-all")
-      fi
-
       if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -416,7 +406,6 @@ spec:
        -e IMAGE="$IMAGE" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
-       -e SQUASH_ALL="$SQUASH_ALL" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -69,8 +69,8 @@ spec:
     type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
-      build --secret' at /run/secrets/$OPTIONAL_SECRET
-    name: OPTIONAL_SECRET
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
     type: string
   - default: ""
     description: In case it is not empty, the prefetched content should be made available
@@ -160,8 +160,8 @@ spec:
       value: $(params.SQUASH)
     - name: SQUASH_ALL
       value: $(params.SQUASH_ALL)
-    - name: OPTIONAL_SECRET
-      value: $(params.OPTIONAL_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -233,7 +233,7 @@ spec:
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
+      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -365,11 +365,11 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      OPTIONAL_SECRET_PATH="/optional-secret"
-      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
@@ -416,7 +416,7 @@ spec:
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
        -e SQUASH_ALL="$SQUASH_ALL" \
-       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
+       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
@@ -427,7 +427,7 @@ spec:
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
+       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -451,8 +451,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
-    - mountPath: /optional-secret
-      name: optional-secret
+    - mountPath: /additional-secret
+      name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -626,10 +626,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
-  - name: optional-secret
+  - name: additional-secret
     secret:
       optional: true
-      secretName: $(params.OPTIONAL_SECRET)
+      secretName: $(params.ADDITIONAL_SECRET)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -16,6 +16,11 @@ spec:
     When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
     When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
   - default: ""
     description: Comma separated list of extra capabilities to add when running 'buildah
       build'
@@ -66,11 +71,6 @@ spec:
       tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
       respectively.
     name: IMAGE_EXPIRES_AFTER
-    type: string
-  - default: does-not-exist
-    description: Name of a secret which will be made available to the build with 'buildah
-      build --secret' at /run/secrets/$ADDITIONAL_SECRET
-    name: ADDITIONAL_SECRET
     type: string
   - default: ""
     description: In case it is not empty, the prefetched content should be made available
@@ -138,6 +138,8 @@ spec:
   stepTemplate:
     computeResources: {}
     env:
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
     - name: BUILDAH_FORMAT
@@ -160,8 +162,6 @@ spec:
       value: $(params.SQUASH)
     - name: SQUASH_ALL
       value: $(params.SQUASH_ALL)
-    - name: ADDITIONAL_SECRET
-      value: $(params.ADDITIONAL_SECRET)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -405,6 +405,7 @@ spec:
       chmod +x scripts/script-build.sh
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
@@ -416,7 +417,6 @@ spec:
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
        -e SQUASH_ALL="$SQUASH_ALL" \
-       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
@@ -622,14 +622,14 @@ spec:
     name: upload-sbom
     workingDir: /var/workdir
   volumes:
-  - name: etc-pki-entitlement
-    secret:
-      optional: true
-      secretName: $(params.ENTITLEMENT_SECRET)
   - name: additional-secret
     secret:
       optional: true
       secretName: $(params.ADDITIONAL_SECRET)
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -68,6 +68,11 @@ spec:
     name: IMAGE_EXPIRES_AFTER
     type: string
   - default: ""
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$OPTIONAL_SECRET
+    name: OPTIONAL_SECRET
+    type: string
+  - default: ""
     description: In case it is not empty, the prefetched content should be made available
       to the build.
     name: PREFETCH_INPUT
@@ -155,6 +160,8 @@ spec:
       value: $(params.SQUASH)
     - name: SQUASH_ALL
       value: $(params.SQUASH_ALL)
+    - name: OPTIONAL_SECRET
+      value: $(params.OPTIONAL_SECRET)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -226,6 +233,7 @@ spec:
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -357,6 +365,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      OPTIONAL_SECRET_PATH="/optional-secret"
+      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      fi
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
         "${BUILDAH_ARGS[@]}" \
@@ -401,6 +416,7 @@ spec:
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
        -e SQUASH_ALL="$SQUASH_ALL" \
+       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
@@ -411,6 +427,7 @@ spec:
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -434,6 +451,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /optional-secret
+      name: optional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -607,6 +626,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - name: optional-secret
+    secret:
+      optional: true
+      secretName: $(params.OPTIONAL_SECRET)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -76,6 +76,15 @@ spec:
       source code.
     name: SOURCE_ARTIFACT
     type: string
+  - default: "false"
+    description: Squash new layers added as a part of this build, as per --squash
+    name: SQUASH
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash-all
+    name: SQUASH_ALL
+    type: string
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
       is processed entirely to (and including) its last stage.
@@ -142,6 +151,10 @@ spec:
       value: $(params.IMAGE)
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SQUASH_ALL
+      value: $(params.SQUASH_ALL)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -293,6 +306,14 @@ spec:
         BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
       fi
 
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SQUASH_ALL}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash-all")
+      fi
+
       if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -378,6 +399,8 @@ spec:
        -e HERMETIC="$HERMETIC" \
        -e IMAGE="$IMAGE" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+       -e SQUASH="$SQUASH" \
+       -e SQUASH_ALL="$SQUASH_ALL" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -356,10 +356,13 @@ spec:
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
-        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
-        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -67,7 +67,7 @@ spec:
       respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
-  - default: ""
+  - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$OPTIONAL_SECRET
     name: OPTIONAL_SECRET

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -100,6 +100,15 @@ spec:
       build'
     name: ADD_CAPABILITIES
     type: string
+  - default: "false"
+    description: Squash new layers added as a part of this build, as per --squash
+    name: SQUASH
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash-all
+    name: SQUASH_ALL
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -151,6 +160,10 @@ spec:
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SQUASH_ALL
+      value: $(params.SQUASH_ALL)
     - name: BUILDER_IMAGE
       value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     volumeMounts:
@@ -285,6 +298,14 @@ spec:
         BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
       fi
 
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SQUASH_ALL}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash-all")
+      fi
+
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -377,6 +398,8 @@ spec:
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+       -e SQUASH="$SQUASH" \
+       -e SQUASH_ALL="$SQUASH_ALL" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -78,7 +78,7 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
-  - default: ""
+  - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$OPTIONAL_SECRET
     name: OPTIONAL_SECRET

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -80,8 +80,8 @@ spec:
     type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
-      build --secret' at /run/secrets/$OPTIONAL_SECRET
-    name: OPTIONAL_SECRET
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
     type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings)
@@ -161,8 +161,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: OPTIONAL_SECRET
-      value: $(params.OPTIONAL_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -221,7 +221,7 @@ spec:
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
+      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -357,11 +357,11 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      OPTIONAL_SECRET_PATH="/optional-secret"
-      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
@@ -411,7 +411,7 @@ spec:
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
+       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
@@ -420,7 +420,7 @@ spec:
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
+       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -444,8 +444,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
-    - mountPath: /optional-secret
-      name: optional-secret
+    - mountPath: /additional-secret
+      name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -627,10 +627,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
-  - name: optional-secret
+  - name: additional-secret
     secret:
       optional: true
-      secretName: $(params.OPTIONAL_SECRET)
+      secretName: $(params.ADDITIONAL_SECRET)
   - configMap:
       items:
       - key: $(params.caTrustConfigMapKey)

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -106,13 +106,9 @@ spec:
     name: ADD_CAPABILITIES
     type: string
   - default: "false"
-    description: Squash new layers added as a part of this build, as per --squash
-    name: SQUASH
-    type: string
-  - default: "false"
     description: Squash all new and previous layers added as a part of this build,
-      as per --squash-all
-    name: SQUASH_ALL
+      as per --squash
+    name: SQUASH
     type: string
   - description: The platform to build on
     name: PLATFORM
@@ -169,8 +165,6 @@ spec:
       value: $(params.ADD_CAPABILITIES)
     - name: SQUASH
       value: $(params.SQUASH)
-    - name: SQUASH_ALL
-      value: $(params.SQUASH_ALL)
     - name: BUILDER_IMAGE
       value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     volumeMounts:
@@ -310,10 +304,6 @@ spec:
         BUILDAH_ARGS+=("--squash")
       fi
 
-      if [ "${SQUASH_ALL}" == "true" ]; then
-        BUILDAH_ARGS+=("--squash-all")
-      fi
-
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -415,7 +405,6 @@ spec:
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
-       -e SQUASH_ALL="$SQUASH_ALL" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -348,10 +348,13 @@ spec:
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
-        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
-        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -479,7 +479,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     name: merge-cachi2-sbom
     script: |
       if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -78,6 +78,11 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
+  - default: ""
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$OPTIONAL_SECRET
+    name: OPTIONAL_SECRET
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings)
     name: BUILD_ARGS
@@ -156,6 +161,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: OPTIONAL_SECRET
+      value: $(params.OPTIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -214,6 +221,7 @@ spec:
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -349,6 +357,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      OPTIONAL_SECRET_PATH="/optional-secret"
+      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      fi
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
         "${BUILDAH_ARGS[@]}" \
@@ -396,6 +411,7 @@ spec:
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
@@ -404,6 +420,7 @@ spec:
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -427,6 +444,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /optional-secret
+      name: optional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -608,6 +627,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - name: optional-secret
+    secret:
+      optional: true
+      secretName: $(params.OPTIONAL_SECRET)
   - configMap:
       items:
       - key: $(params.caTrustConfigMapKey)

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -565,7 +565,13 @@ spec:
       container=$(buildah from --pull-never $IMAGE)
       buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-      buildah commit $container $IMAGE
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
       status=-1
       max_run=5

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -351,10 +351,10 @@ spec:
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
         cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
-        for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+        while read -r filename; do
           echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
           BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
-        done
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -23,6 +23,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -26,8 +26,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
-|SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|
-|SQUASH_ALL|Squash all new and previous layers added as a part of this build, as per --squash-all|false|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -25,6 +25,8 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|
+|SQUASH_ALL|Squash all new and previous layers added as a part of this build, as per --squash-all|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -23,7 +23,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
-|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -467,7 +467,13 @@ spec:
       container=$(buildah from --pull-never $IMAGE)
       buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-      buildah commit $container $IMAGE
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
       status=-1
       max_run=5

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -91,6 +91,14 @@ spec:
     description: Comma separated list of extra capabilities to add when running 'buildah build'
     type: string
     default: ""
+  - name: SQUASH
+    description: Squash new layers added as a part of this build, as per --squash
+    type: string
+    default: "false"
+  - name: SQUASH_ALL
+    description: Squash all new and previous layers added as a part of this build, as per --squash-all
+    type: string
+    default: "false"
 
   results:
   - description: Digest of the image just built
@@ -141,6 +149,10 @@ spec:
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SQUASH_ALL
+      value: $(params.SQUASH_ALL)
 
   steps:
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
@@ -231,6 +243,14 @@ spec:
 
       if [ -n "${ADD_CAPABILITIES}" ]; then
         BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SQUASH_ALL}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash-all")
       fi
 
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -293,10 +293,13 @@ spec:
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
-        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
-        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -71,6 +71,10 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
+  - name: OPTIONAL_SECRET
+    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+    type: string
+    default: ""
   - name: BUILD_ARGS
     description: Array of --build-arg values ("arg=value" strings)
     type: array
@@ -145,6 +149,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: OPTIONAL_SECRET
+      value: $(params.OPTIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -296,6 +302,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      OPTIONAL_SECRET_PATH="/optional-secret"
+      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      fi
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
         "${BUILDAH_ARGS[@]}" \
@@ -333,6 +346,8 @@ spec:
       name: varlibcontainers
     - mountPath: "/entitlement"
       name: etc-pki-entitlement
+    - mountPath: "/optional-secret"
+      name: optional-secret
     - name: trusted-ca
       mountPath: /mnt/trusted-ca
       readOnly: true
@@ -514,6 +529,10 @@ spec:
   - name: etc-pki-entitlement
     secret:
       secretName: $(params.ENTITLEMENT_SECRET)
+      optional: true
+  - name: optional-secret
+    secret:
+      secretName: $(params.OPTIONAL_SECRET)
       optional: true
   - name: trusted-ca
     configMap:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -296,10 +296,10 @@ spec:
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
         cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
-        for filename in $(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;); do
+        while read -r filename; do
           echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
           BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
-        done
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -74,7 +74,7 @@ spec:
   - name: OPTIONAL_SECRET
     description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
     type: string
-    default: ""
+    default: "does-not-exist"
   - name: BUILD_ARGS
     description: Array of --build-arg values ("arg=value" strings)
     type: array

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -387,7 +387,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     script: |
       if [ -f "sbom-cachi2.json" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -71,8 +71,8 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
-  - name: OPTIONAL_SECRET
-    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+  - name: ADDITIONAL_SECRET
+    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
     type: string
     default: "does-not-exist"
   - name: BUILD_ARGS
@@ -149,8 +149,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: OPTIONAL_SECRET
-      value: $(params.OPTIONAL_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -302,11 +302,11 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      OPTIONAL_SECRET_PATH="/optional-secret"
-      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
@@ -346,8 +346,8 @@ spec:
       name: varlibcontainers
     - mountPath: "/entitlement"
       name: etc-pki-entitlement
-    - mountPath: "/optional-secret"
-      name: optional-secret
+    - mountPath: "/additional-secret"
+      name: additional-secret
     - name: trusted-ca
       mountPath: /mnt/trusted-ca
       readOnly: true
@@ -530,9 +530,9 @@ spec:
     secret:
       secretName: $(params.ENTITLEMENT_SECRET)
       optional: true
-  - name: optional-secret
+  - name: additional-secret
     secret:
-      secretName: $(params.OPTIONAL_SECRET)
+      secretName: $(params.ADDITIONAL_SECRET)
       optional: true
   - name: trusted-ca
     configMap:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -96,11 +96,7 @@ spec:
     type: string
     default: ""
   - name: SQUASH
-    description: Squash new layers added as a part of this build, as per --squash
-    type: string
-    default: "false"
-  - name: SQUASH_ALL
-    description: Squash all new and previous layers added as a part of this build, as per --squash-all
+    description: Squash all new and previous layers added as a part of this build, as per --squash
     type: string
     default: "false"
 
@@ -157,8 +153,6 @@ spec:
       value: $(params.ADD_CAPABILITIES)
     - name: SQUASH
       value: $(params.SQUASH)
-    - name: SQUASH_ALL
-      value: $(params.SQUASH_ALL)
 
   steps:
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
@@ -253,10 +247,6 @@ spec:
 
       if [ "${SQUASH}" == "true" ]; then
         BUILDAH_ARGS+=("--squash")
-      fi
-
-      if [ "${SQUASH_ALL}" == "true" ]; then
-        BUILDAH_ARGS+=("--squash-all")
       fi
 
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -28,7 +28,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-image-manifests
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # the clair-in-ci image neither has skopeo or jq installed. Hence, we create an extra step to get the image manifest digests
       env:
         - name: IMAGE_URL
@@ -91,7 +91,7 @@ spec:
         images_processed=$(echo "${images_processed_template/\[%s]/[$digests_processed_string]}")
         echo "$images_processed" > /tekton/home/images-processed.json
     - name: conftest-vulnerabilities
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       securityContext:

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -194,6 +194,6 @@ spec:
           name: dbfolder
   volumes:
     - name: dbfolder
-      emptydir: {}
+      emptyDir: {}
     - name: work
-      emptydir: {}
+      emptyDir: {}

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -26,7 +26,7 @@ spec:
 
   steps:
     - name: extract-and-scan-image
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: /work

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:
@@ -61,7 +61,7 @@ spec:
 
     # Run the tests and save output
     - name: run-conftest
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:
@@ -61,7 +61,7 @@ spec:
 
     # Run the tests and save output
     - name: run-conftest
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -29,7 +29,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -34,7 +34,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/eaas-provision-space/OWNERS
+++ b/task/eaas-provision-space/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - amisstea
-- oamsalem
+- omeramsc
 - avi-biton
 - yftacherzog
 - hmariset

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -41,7 +41,7 @@ spec:
         # however there is also posibility that catalog.yaml has yaml data in it
 
         status=0
-        relImgs="$(jq -r '.relatedImages[]?.image' <<< ${catalog)" || status=$?
+        relImgs="$(jq -r '.relatedImages[]?.image' <<< ${catalog})" || status=$?
         if [ $status -ne 0 ]; then
           echo "Could not get related images. Make sure catalog.yaml exists in FBC fragment image and it is valid .yaml or .json format."
           note="Task $(context.task.name) failed: Could not fetch related images. Make sure you have catalog.yaml or catalog.json formatted correctly in your file-based catalog (FBC) fragment image."

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -17,7 +17,7 @@ spec:
     - name: workspace
   steps:
     - name: check-related-images
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -34,25 +34,20 @@ spec:
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
         FAILEDIMAGES=""
-        catalog="$(find $(workspaces.workspace.path)/hacbs/fbc-validation/ -name catalog.yaml)"
+        catalog="$(opm render $(workspaces.workspace.path)/hacbs/fbc-validation/confdir/)"
 
         # OPM generates catalog file in a way that yaml file could contain stream of JSON objects
         # thats why we need jq in for this situation, because yq can't parse this file
         # however there is also posibility that catalog.yaml has yaml data in it
 
         status=0
-        relImgs="$(yq -r '.relatedImages[]?.image' $catalog)" || status=$?
+        relImgs="$(jq -r '.relatedImages[]?.image' <<< ${catalog)" || status=$?
         if [ $status -ne 0 ]; then
-          echo "Processing the catalog with yq failed because catalog.yaml contains data type other than yaml. Attempting to process with jq..."
-          status=0
-          relImgs="$(jq -r '.relatedImages[]?.image' $catalog)" || status=$?
-          if [ $status -ne 0 ]; then
-            echo "Could not get related images. Make sure catalog.yaml exists in FBC fragment image and it is valid .yaml format."
-            note="Task $(context.task.name) failed: Could not fetch related images. Make sure you have catalog.yaml formatted correctly in your file-based catalog (FBC) fragment image."
-            TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
-            echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          echo "Could not get related images. Make sure catalog.yaml exists in FBC fragment image and it is valid .yaml or .json format."
+          note="Task $(context.task.name) failed: Could not fetch related images. Make sure you have catalog.yaml or catalog.json formatted correctly in your file-based catalog (FBC) fragment image."
+          TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
           exit 0
-          fi
         fi
 
         echo -e "These are related images:\n$relImgs."

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -26,7 +26,7 @@ spec:
     - name: workspace
   steps:
     - name: extract-and-check-binaries
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -263,7 +263,7 @@ spec:
         check_symlinks() {
           FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
           while read symlink; do
-            target=$(readlink -f "$symlink")
+            target=$(readlink -m "$symlink")
             if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
               echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
               FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -265,7 +265,7 @@ spec:
         FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
         while read symlink
         do
-          target=$(readlink -f "$symlink")
+          target=$(readlink -m "$symlink")
           if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
             echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
             FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true

--- a/task/inspect-image/0.1/inspect-image.yaml
+++ b/task/inspect-image/0.1/inspect-image.yaml
@@ -33,7 +33,7 @@ spec:
     - name: source
   steps:
   - name: inspect-image
-    image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+    image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,6 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,7 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|""|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -15,4 +15,5 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 |---|---|
 |IMAGE_DIGEST|Digest of the artifact just pushed|
 |IMAGE_URL|Repository where the artifact was pushed|
+|SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
 

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -13,6 +13,11 @@ spec:
   description: Given a file in the user's source directory, copy content from
     arbitrary urls into the OCI registry.
   params:
+    - name: BEARER_TOKEN_SECRET_NAME
+      description: Name of a secret which will be made available to the build
+        as an Authorization header
+      type: string
+      default: ""
     - name: IMAGE
       description: Reference of the image we will push
       type: string
@@ -85,16 +90,33 @@ spec:
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
+      env:
+        - name: BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: $(params.BEARER_TOKEN_SECRET_NAME)
+              optional: true
       script: |
-        set -eu
+        set -e
         set -o pipefail
+
+        CURL_ARGS=()
+        if [ -n "${BEARER_TOKEN}" ]; then
+          echo "Found bearer token. Using it for authentication."
+          CURL_ARGS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
+        else
+          echo "Proceeding with anonymous requests"
+        fi
+
+        set -u
 
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -122,7 +122,7 @@ spec:
         echo "Extracting artifact_type"
         ARTIFACT_TYPE=$(cat "$(pwd)/source/$OCI_COPY_FILE" | yq '.artifact_type')
 
-        REPO=$(echo ${IMAGE} | awk -F ':' '{print $1}')
+        REPO=${IMAGE%:*}
         echo "Found that ${REPO} is the repository for ${IMAGE}"
 
         cat >artifact-manifest.json <<EOL

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -15,7 +15,10 @@ spec:
   params:
     - name: BEARER_TOKEN_SECRET_NAME
       description: Name of a secret which will be made available to the build
-        as an Authorization header
+        as an Authorization header. Note, the token will be sent to all servers
+        found in the oci-copy.yaml file. If you do not wish to send the token
+        to all servers, different taskruns and therefore different oci artifacts
+        must be used.
       type: string
       default: ""
     - name: IMAGE
@@ -116,7 +119,7 @@ spec:
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -37,6 +37,8 @@ spec:
       description: Digest of the artifact just pushed
     - name: IMAGE_URL
       description: Repository where the artifact was pushed
+    - name: SBOM_BLOB_URL
+      description: Link to the SBOM blob pushed to the registry.
   volumes:
     - name: varlibcontainers
       emptyDir: {}
@@ -191,3 +193,12 @@ spec:
         - cyclonedx
         - $(params.IMAGE)
       workingDir: /var/workdir
+    - name: report-sbom-url
+      image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
+      workingDir: /var/workdir
+      script: |
+        REPO=${IMAGE%:*}
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
+        SBOM_DIGEST=$(sha256sum sbom-cyclonedx.json | awk '{ print $1 }')
+        echo "Found that ${SBOM_DIGEST} is the SBOM digest"
+        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -116,36 +116,75 @@ spec:
 
         set -u
 
-        for varfile in /var/workdir/vars/*; do
-          echo "Reading $varfile"
-          source $varfile
-
-          echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
-
-          echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
-          echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
-
-          echo "Appending to arguments for $OCI_FILENAME of type $OCI_ARTIFACT_TYPE"
-          args+=("${OCI_FILENAME}:${OCI_ARTIFACT_TYPE}")
-        done
-
-        if [ -z "${args}" ]; then
-          echo "No files found. Something is very wrong. Skipping upload."
-          exit 1
-        fi
+        echo "Selecting auth for $IMAGE"
+        select-oci-auth $IMAGE >auth.json
 
         echo "Extracting artifact_type"
         ARTIFACT_TYPE=$(cat "$(pwd)/source/$OCI_COPY_FILE" | yq '.artifact_type')
 
-        echo "Selecting auth for $IMAGE"
-        select-oci-auth $IMAGE >auth.json
+        REPO=$(echo ${IMAGE} | awk -F ':' '{print $1}')
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
 
-        echo "Pushing contents to ${IMAGE}"
-        oras push --no-tty --registry-config auth.json --artifact-type ${ARTIFACT_TYPE} "${IMAGE}" "${args[@]}"
+        cat >artifact-manifest.json <<EOL
+        {
+          "schemaVersion": 2,
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "artifactType": "${ARTIFACT_TYPE}",
+          "config": {
+            "mediaType": "application/vnd.oci.empty.v1+json",
+            "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            "size": 2,
+            "data": "e30="
+          },
+          "layers": [],
+          "annotations": {
+            "org.opencontainers.image.created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+        }
+        EOL
 
-        IMAGE_INDEX_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
-        echo -n "$IMAGE_INDEX_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        for varfile in /var/workdir/vars/*; do
+          echo "Reading $varfile"
+          source $varfile
+
+          echo "Checking to see if blob $OCI_ARTIFACT_DIGEST exists"
+          if [[ $(oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}") ]]; then
+            echo "Blob for ${OCI_FILENAME} already exists in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}. Skipping download."
+          else
+            echo "Blob for ${OCI_FILENAME} does not yet exist in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}."
+            echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
+            curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+
+            echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
+            echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
+
+            echo "Pushing blob of $OCI_FILENAME of type $OCI_ARTIFACT_TYPE"
+            oras blob push --registry-config auth.json ${REPO} --media-type ${OCI_ARTIFACT_TYPE} ${OCI_FILENAME}
+
+            echo "Removing local copy of $OCI_FILENAME to save space."
+            rm ${OCI_FILENAME}
+          fi
+
+          echo "Grabbing descriptor of blob from the registry"
+          oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" >descriptor.json
+
+          echo "Setting mediaType to ${OCI_ARTIFACT_TYPE}"
+          yq -oj -i '.mediaType = "'${OCI_ARTIFACT_TYPE}'"' descriptor.json
+
+          echo "Inserting org.opencontainers.image.title = ${OCI_FILENAME} annotation"
+          yq -oj -i '.annotations."org.opencontainers.image.title" = "'${OCI_FILENAME}'"' descriptor.json
+
+          echo "Appending blob descriptor for ${OCI_FILENAME} to the overall artifact manifest for ${IMAGE}"
+          yq -oj -i ".layers += $(cat descriptor.json)" artifact-manifest.json
+
+          echo "Done with ${OCI_FILENAME}."
+        done
+
+        echo "Pushing complete artifact manifest to ${IMAGE}"
+        oras manifest push --no-tty --registry-config auth.json "${IMAGE}" artifact-manifest.json
+
+        RESULTING_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
         echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
       computeResources:
         limits:

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -11,6 +11,7 @@ It is not to be considered safe for general use as it cannot provide a high degr
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -21,6 +21,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |---|---|
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
+|SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
 
 ## Workspaces
 |name|description|optional|

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -6,12 +6,15 @@ It generates a limited SBOM and pushes that into the OCI registry alongside the 
 
 It is not to be considered safe for general use as it cannot provide a high degree of provenance for artficats and reports them only as "general" type artifacts in the purl spec it reports in the SBOM. Use only in limited situations.
 
+Note: the bearer token secret, if specified, will be sent to **all servers listed in the oci-copy.yaml file**.
+
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|""|false|
+
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -18,6 +18,10 @@ spec:
       description: Path to the oci copy file.
       name: OCI_COPY_FILE
       type: string
+    - name: BEARER_TOKEN_SECRET_NAME
+      description: Name of a secret which will be made available to the build as an Authorization header
+      type: string
+      default: ""
   results:
     - description: Digest of the artifact just pushed
       name: IMAGE_DIGEST
@@ -71,16 +75,33 @@ spec:
         capabilities:
           add:
             - SETFCAP
+      env:
+      - name: BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: $(params.BEARER_TOKEN_SECRET_NAME)
+            key: token
+            optional: true
       script: |
-        set -eu
+        set -e
         set -o pipefail
+
+        CURL_ARGS=()
+        if [ -n "${BEARER_TOKEN}" ]; then
+          echo "Found bearer token. Using it for authentication."
+          CURL_ARGS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
+        else
+          echo "Proceeding with anonymous requests"
+        fi
+
+        set -u
 
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -107,7 +107,7 @@ spec:
         echo "Extracting artifact_type"
         ARTIFACT_TYPE=$(cat "$(pwd)/source/$OCI_COPY_FILE" | yq '.artifact_type')
 
-        REPO=$(echo ${IMAGE} | awk -F ':' '{print $1}')
+        REPO=${IMAGE%:*}
         echo "Found that ${REPO} is the repository for ${IMAGE}"
 
         cat >artifact-manifest.json <<EOL

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -101,36 +101,75 @@ spec:
 
         set -u
 
-        for varfile in /var/workdir/vars/*; do
-          echo "Reading $varfile"
-          source $varfile
-
-          echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
-
-          echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
-          echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
-
-          echo "Appending to arguments for $OCI_FILENAME of type $OCI_ARTIFACT_TYPE"
-          args+=("${OCI_FILENAME}:${OCI_ARTIFACT_TYPE}")
-        done
-
-        if [ -z "${args}" ]; then
-          echo "No files found. Something is very wrong. Skipping upload."
-          exit 1;
-        fi
+        echo "Selecting auth for $IMAGE"
+        select-oci-auth $IMAGE > auth.json
 
         echo "Extracting artifact_type"
         ARTIFACT_TYPE=$(cat "$(pwd)/source/$OCI_COPY_FILE" | yq '.artifact_type')
 
-        echo "Selecting auth for $IMAGE"
-        select-oci-auth $IMAGE > auth.json
+        REPO=$(echo ${IMAGE} | awk -F ':' '{print $1}')
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
 
-        echo "Pushing contents to ${IMAGE}"
-        oras push --no-tty --registry-config auth.json --artifact-type ${ARTIFACT_TYPE} "${IMAGE}" "${args[@]}"
+        cat >artifact-manifest.json <<EOL
+        {
+          "schemaVersion": 2,
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "artifactType": "${ARTIFACT_TYPE}",
+          "config": {
+            "mediaType": "application/vnd.oci.empty.v1+json",
+            "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            "size": 2,
+            "data": "e30="
+          },
+          "layers": [],
+          "annotations": {
+            "org.opencontainers.image.created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+        }
+        EOL
 
-        IMAGE_INDEX_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
-        echo -n "$IMAGE_INDEX_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        for varfile in /var/workdir/vars/*; do
+          echo "Reading $varfile"
+          source $varfile
+
+          echo "Checking to see if blob $OCI_ARTIFACT_DIGEST exists"
+          if [[ $(oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}") ]]; then
+            echo "Blob for ${OCI_FILENAME} already exists in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}. Skipping download."
+          else
+            echo "Blob for ${OCI_FILENAME} does not yet exist in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}."
+            echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
+            curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+
+            echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
+            echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
+
+            echo "Pushing blob of $OCI_FILENAME of type $OCI_ARTIFACT_TYPE"
+            oras blob push --registry-config auth.json ${REPO} --media-type ${OCI_ARTIFACT_TYPE} ${OCI_FILENAME}
+
+            echo "Removing local copy of $OCI_FILENAME to save space."
+            rm ${OCI_FILENAME}
+          fi
+
+          echo "Grabbing descriptor of blob from the registry"
+          oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" > descriptor.json
+
+          echo "Setting mediaType to ${OCI_ARTIFACT_TYPE}"
+          yq -oj -i '.mediaType = "'${OCI_ARTIFACT_TYPE}'"' descriptor.json
+
+          echo "Inserting org.opencontainers.image.title = ${OCI_FILENAME} annotation"
+          yq -oj -i '.annotations."org.opencontainers.image.title" = "'${OCI_FILENAME}'"' descriptor.json
+
+          echo "Appending blob descriptor for ${OCI_FILENAME} to the overall artifact manifest for ${IMAGE}"
+          yq -oj -i ".layers += $(cat descriptor.json)" artifact-manifest.json
+
+          echo "Done with ${OCI_FILENAME}."
+        done
+
+        echo "Pushing complete artifact manifest to ${IMAGE}"
+        oras manifest push --no-tty --registry-config auth.json "${IMAGE}" artifact-manifest.json
+
+        RESULTING_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
         echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -30,6 +30,8 @@ spec:
       name: IMAGE_DIGEST
     - description: Repository where the artifact was pushed
       name: IMAGE_URL
+    - description: Link to the SBOM blob pushed to the registry.
+      name: SBOM_BLOB_URL
   stepTemplate:
     env:
       - name: OCI_COPY_FILE
@@ -170,7 +172,15 @@ spec:
         - cyclonedx
         - $(params.IMAGE)
       workingDir: $(workspaces.source.path)
-
+    - name: report-sbom-url
+      image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
+      script: |
+        REPO=${IMAGE%:*}
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
+        SBOM_DIGEST=$(sha256sum sbom-cyclonedx.json | awk '{ print $1 }')
+        echo "Found that ${SBOM_DIGEST} is the SBOM digest"
+        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)
+      workingDir: $(workspaces.source.path)
   volumes:
     - emptyDir: {}
       name: varlibcontainers

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -19,7 +19,10 @@ spec:
       name: OCI_COPY_FILE
       type: string
     - name: BEARER_TOKEN_SECRET_NAME
-      description: Name of a secret which will be made available to the build as an Authorization header
+      description: >-
+        Name of a secret which will be made available to the build as an Authorization header. Note, the token will
+        be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers,
+        different taskruns and therefore different oci artifacts must be used.
       type: string
       default: ""
   results:

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -101,7 +101,7 @@ spec:
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/prefetch-dependencies-oci-ta/0.1/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.1/README.md
@@ -27,3 +27,4 @@ https://github.com/containerbuildsystem/cachi2#basic-usage.
 |name|description|optional|
 |---|---|---|
 |git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -73,6 +73,11 @@ spec:
         other files in this Workspace are ignored. It is strongly recommended
         to bind a Secret to this Workspace over other volume types.
       optional: true
+    - name: netrc
+      description: |
+        Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+        performing http(s) requests.
+      optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -116,6 +121,10 @@ spec:
           value: $(workspaces.git-basic-auth.bound)
         - name: WORKSPACE_GIT_AUTH_PATH
           value: $(workspaces.git-basic-auth.path)
+        - name: WORKSPACE_NETRC_BOUND
+          value: $(workspaces.netrc.bound)
+        - name: WORKSPACE_NETRC_PATH
+          value: $(workspaces.netrc.path)
       script: |
         if [ -z "${INPUT}" ]; then
           # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
@@ -145,6 +154,10 @@ spec:
           fi
           chmod 400 "${HOME}/.git-credentials"
           chmod 400 "${HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+          cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
         fi
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -100,7 +100,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: prefetch-dependencies
-      image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+      image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/prefetch-dependencies/0.1/README.md
+++ b/task/prefetch-dependencies/0.1/README.md
@@ -17,3 +17,4 @@ See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
 |---|---|---|
 |source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
 |git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -31,7 +31,7 @@ spec:
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
   steps:
-  - image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+  - image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: prefetch-dependencies

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -46,6 +46,10 @@ spec:
       value: $(workspaces.git-basic-auth.bound)
     - name: WORKSPACE_GIT_AUTH_PATH
       value: $(workspaces.git-basic-auth.path)
+    - name: WORKSPACE_NETRC_BOUND
+      value: $(workspaces.netrc.bound)
+    - name: WORKSPACE_NETRC_PATH
+      value: $(workspaces.netrc.path)
     volumeMounts:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
@@ -82,6 +86,10 @@ spec:
         chmod 400 "${HOME}/.gitconfig"
       fi
 
+      if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+        cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+      fi
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -111,6 +119,11 @@ spec:
       These will be copied to the user's home before any cachi2 commands are run. Any
       other files in this Workspace are ignored. It is strongly recommended
       to bind a Secret to this Workspace over other volume types.
+    optional: true
+  - name: netrc
+    description: |
+      Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+      performing http(s) requests.
     optional: true
   volumes:
     - name: trusted-ca

--- a/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
@@ -58,7 +58,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: sast-snyk-check
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /etc/secrets

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -38,7 +38,7 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -20,7 +20,7 @@ spec:
       name: IMAGES_PROCESSED
   steps:
   - name: sbom-json-check
-    image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+    image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     securityContext:

--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -53,7 +53,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:0d199c56ed01b88f8a7d244742989bfc63980e8624cc6cc8f792d79f6ece40be
+      image: quay.io/konflux-ci/source-container-build:9ad131acf5154d2f280b7b46a1abc543952d325c@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
       workingDir: /var/workdir
       env:
         - name: BINARY_IMAGE

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -36,7 +36,7 @@ spec:
       emptyDir: {}
   steps:
     - name: build
-      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:0d199c56ed01b88f8a7d244742989bfc63980e8624cc6cc8f792d79f6ece40be
+      image: quay.io/konflux-ci/source-container-build:9ad131acf5154d2f280b7b46a1abc543952d325c@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       computeResources:

--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -48,7 +48,7 @@ spec:
           --workdir "${WORKDIR}" \
           --status-path "${WORKDIR}"/status
     - name: output-results
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       volumeMounts:
         - name: workdir
           mountPath: "$(params.WORKDIR)"


### PR DESCRIPTION
Optionally, let the user re-tag the source image before building a disk image from it. This is useful if you want to build from an unreleased image, but have the history of the image appear as if it was built from a released pullspec of that same image.